### PR TITLE
Fix: Add "user" role to mobile authentication check

### DIFF
--- a/src/features/notifications/push/routes/pushNotification.routes.ts
+++ b/src/features/notifications/push/routes/pushNotification.routes.ts
@@ -13,7 +13,7 @@ const router = express.Router();
 router.post(
     '/register-fmc-token',
     authenticateJWT,
-    authorizeRoles('admin', 'moderator'),
+    authorizeRoles('admin', 'moderator', 'user'),
     registerFmcToken
 );
 

--- a/test-api/utils/auth.middleware.test.ts
+++ b/test-api/utils/auth.middleware.test.ts
@@ -99,9 +99,25 @@ describe('authorizeRoles', () => {
         json: jest.fn(),
     } as any;
 
-    it('should call next if user role is allowed', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should call next if admin role is allowed', () => {
         const req = { user: { role: 'admin' } } as any;
         authorizeRoles('admin', 'moderator')(req, res, next);
+        expect(next).toHaveBeenCalled();
+    });
+
+    it('should call next if moderator role is allowed', () => {
+        const req = { user: { role: 'moderator' } } as any;
+        authorizeRoles('admin', 'moderator')(req, res, next);
+        expect(next).toHaveBeenCalled();
+    });
+
+    it('should call next if user role is explicitly allowed', () => {
+        const req = { user: { role: 'user' } } as any;
+        authorizeRoles('admin', 'moderator', 'user')(req, res, next);
         expect(next).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Hotfix

### Type of change
- [x] fix - Permission handling update for mobile users

### Brief description
Add "user" role to authentication check for mobile permissions